### PR TITLE
Update OR syntax

### DIFF
--- a/pyvdrm/asi2.py
+++ b/pyvdrm/asi2.py
@@ -81,7 +81,7 @@ class OrExpr(AsiMultipleExpr):
         for arg in self.children:
             score = arg(mutations)
             if score is not None and score.score:
-                return Score(score.score, score.residues)
+                return score
         else:
             return Score(False, [])
 

--- a/pyvdrm/asi2.py
+++ b/pyvdrm/asi2.py
@@ -74,22 +74,16 @@ class AndExpr(AsiExpr):
         return Score(True, residues)
 
 
-class OrExpr(AsiBinaryExpr):
+class OrExpr(AsiExpr):
     """Boolean OR on children (binary only)"""
 
     def __call__(self, mutations):
-        arg1, arg2 = self.children
-
-        score1 = arg1(mutations)
-        score2 = arg2(mutations)
-
-        if score1 is None:
-            score1 = Score(False, [])
-        if score2 is None:
-            score2 = Score(False, [])
-
-        return Score(score1.score or score2.score,
-                     score1.residues | score2.residues)
+        for arg in self.children:
+            score = arg(mutations)
+            if score is not None:
+                return Score(score.score, score.residues)
+        else:
+            return Score(False, [])
 
 
 class EqualityExpr(AsiExpr):

--- a/pyvdrm/asi2.py
+++ b/pyvdrm/asi2.py
@@ -5,7 +5,7 @@ ASI2 Parser definition
 from functools import reduce, total_ordering
 from pyparsing import (Literal, nums, Word, Forward, Optional, Regex,
                        infixNotation, delimitedList, opAssoc, ParseException)
-from pyvdrm.drm import AsiExpr, AsiBinaryExpr, DRMParser, MissingPositionError
+from pyvdrm.drm import AsiExpr, AsiMultipleExpr, DRMParser, MissingPositionError
 from pyvdrm.vcf import MutationSet
 
 
@@ -74,13 +74,13 @@ class AndExpr(AsiExpr):
         return Score(True, residues)
 
 
-class OrExpr(AsiExpr):
-    """Boolean OR on children (binary only)"""
+class OrExpr(AsiMultipleExpr):
+    """Boolean OR on children (not necessarily binary)"""
 
     def __call__(self, mutations):
         for arg in self.children:
             score = arg(mutations)
-            if score is not None:
+            if score is not None and score.score:
                 return Score(score.score, score.residues)
         else:
             return Score(False, [])

--- a/pyvdrm/drm.py
+++ b/pyvdrm/drm.py
@@ -70,8 +70,7 @@ class AsiBinaryExpr(AsiExpr):
 
     def typecheck(self, tokens):
         if len(tokens[0]) != 2:
-            pass
-            #raise AsiParseError
+            raise AsiParseError
 
     def __repr__(self):
         arg1, arg2 = self.children

--- a/pyvdrm/drm.py
+++ b/pyvdrm/drm.py
@@ -77,6 +77,14 @@ class AsiBinaryExpr(AsiExpr):
         return "{} {} {}".format(arg1, type(self), arg2)
 
 
+class AsiMultipleExpr(AsiExpr):
+    """Subclass with syntactic sugar for boolean ops"""
+
+    def __init__(self, label, pos, tokens):
+        super().__init__(label, pos, tokens)
+        self.children = tokens[0]
+
+
 class AsiUnaryExpr(AsiExpr):
     """Subclass for atoms and unary ops"""
 

--- a/pyvdrm/drm.py
+++ b/pyvdrm/drm.py
@@ -61,22 +61,6 @@ class AsiExpr(object):
         return self.children(args)
 
 
-class AsiBinaryExpr(AsiExpr):
-    """Subclass with syntactic sugar for boolean ops"""
-
-    def __init__(self, label, pos, tokens):
-        super().__init__(label, pos, tokens)
-        self.children = tokens[0]
-
-    def typecheck(self, tokens):
-        if len(tokens[0]) != 2:
-            raise AsiParseError
-
-    def __repr__(self):
-        arg1, arg2 = self.children
-        return "{} {} {}".format(arg1, type(self), arg2)
-
-
 class AsiMultipleExpr(AsiExpr):
     """Subclass with syntactic sugar for boolean ops"""
 

--- a/pyvdrm/drm.py
+++ b/pyvdrm/drm.py
@@ -70,7 +70,8 @@ class AsiBinaryExpr(AsiExpr):
 
     def typecheck(self, tokens):
         if len(tokens[0]) != 2:
-            raise AsiParseError
+            pass
+            #raise AsiParseError
 
     def __repr__(self):
         arg1, arg2 = self.children

--- a/pyvdrm/hcvr.py
+++ b/pyvdrm/hcvr.py
@@ -102,18 +102,12 @@ class OrExpr(AsiBinaryExpr):
     """Boolean OR on children (binary only)"""
 
     def __call__(self, mutations):
-        arg1, arg2 = self.children
-
-        score1 = arg1(mutations)
-        score2 = arg2(mutations)
-
-        if score1 is None:
-            score1 = Score(False, [])
-        if score2 is None:
-            score2 = Score(False, [])
-
-        return Score(score1.score or score2.score,
-                     score1.residues | score2.residues)
+        for arg in self.children:
+            score = arg(mutations)
+            if score is not None:
+                return Score(score.score, score.residues)
+        else:
+            return Score(False, [])
 
 
 class EqualityExpr(AsiExpr):

--- a/pyvdrm/hcvr.py
+++ b/pyvdrm/hcvr.py
@@ -98,7 +98,7 @@ class AndExpr(AsiExpr):
         return Score(True, residues)
 
 
-class OrExpr(AsiBinaryExpr):
+class OrExpr(AsiExpr):
     """Boolean OR on children (binary only)"""
 
     def __call__(self, mutations):

--- a/pyvdrm/hcvr.py
+++ b/pyvdrm/hcvr.py
@@ -105,7 +105,7 @@ class OrExpr(AsiMultipleExpr):
         for arg in self.children:
             score = arg(mutations)
             if score is not None and score.score:
-                return Score(score.score, score.residues)
+                return score
         else:
             return Score(False, [])
 

--- a/pyvdrm/hcvr.py
+++ b/pyvdrm/hcvr.py
@@ -7,7 +7,7 @@ from pyparsing import (Literal, nums, Word, Forward, Optional, Regex,
                        infixNotation, delimitedList, opAssoc, ParseException)
 
 from pyvdrm.drm import MissingPositionError
-from pyvdrm.drm import AsiExpr, AsiBinaryExpr, DRMParser
+from pyvdrm.drm import AsiExpr, AsiMultipleExpr, DRMParser
 from pyvdrm.vcf import MutationSet
 
 
@@ -98,13 +98,13 @@ class AndExpr(AsiExpr):
         return Score(True, residues)
 
 
-class OrExpr(AsiExpr):
-    """Boolean OR on children (binary only)"""
+class OrExpr(AsiMultipleExpr):
+    """Boolean OR on children (not necessarily binary)"""
 
     def __call__(self, mutations):
         for arg in self.children:
             score = arg(mutations)
-            if score is not None:
+            if score is not None and score.score:
                 return Score(score.score, score.residues)
         else:
             return Score(False, [])

--- a/pyvdrm/tests/test_asi2.py
+++ b/pyvdrm/tests/test_asi2.py
@@ -98,6 +98,12 @@ class TestRuleSemantics(unittest.TestCase):
         self.assertFalse(rule(VariantCalls("1d 2d 7d")))
         self.assertTrue(rule(VariantCalls("1G 2d 7d")))
 
+    def test_bool_or_no_brackets(self):
+        rule = ASI2("1G OR 2T OR 7Y")
+        self.assertTrue(rule(VariantCalls("1d 2T 7d")))
+        self.assertFalse(rule(VariantCalls("1d 2d 7d")))
+        self.assertTrue(rule(VariantCalls("1G 2d 7d")))
+
     def test_select_from_atleast(self):
         rule = ASI2("SELECT ATLEAST 2 FROM (2T, 7Y, 3G)")
         self.assertTrue(rule(VariantCalls("2T 7Y 3d")))

--- a/pyvdrm/tests/test_asi2.py
+++ b/pyvdrm/tests/test_asi2.py
@@ -117,7 +117,7 @@ class TestRuleSemantics(unittest.TestCase):
 
     def test_parse_exception(self):
         expected_error_message = (
-            "Error in ASI2: SCORE FROM ( 10R => 2>!<;0 ) (at char 21), (line:1, col:22)")
+            "Error in ASI2: SCORE FROM ( 10R => 2>!<;0 ), found ';'  (at char 21), (line:1, col:22)")
 
         with self.assertRaises(ParseException) as context:
             ASI2("SCORE FROM ( 10R => 2;0 )")
@@ -131,7 +131,7 @@ SCORE FROM (
 )
 """
         expected_error_message = (
-            "Error in ASI2: 10R => 2>!<;0 (at char 25), (line:2, col:13)")
+            "Error in ASI2: 10R => 2>!<;0, found ';'  (at char 25), (line:2, col:13)")
 
         with self.assertRaises(ParseException) as context:
             ASI2(rule)

--- a/pyvdrm/tests/test_hcvr.py
+++ b/pyvdrm/tests/test_hcvr.py
@@ -155,7 +155,7 @@ class TestRuleSemantics(unittest.TestCase):
 
     def test_parse_exception(self):
         expected_error_message = (
-            "Error in HCVR: SCORE FROM ( 10R => 2>!<;0 ) (at char 21), (line:1, col:22)")
+            "Error in HCVR: SCORE FROM ( 10R => 2>!<;0 ), found ';'  (at char 21), (line:1, col:22)")
 
         with self.assertRaises(ParseException) as context:
             HCVR("SCORE FROM ( 10R => 2;0 )")
@@ -169,7 +169,7 @@ SCORE FROM (
 )
 """
         expected_error_message = (
-            "Error in HCVR: 10R => 2>!<;0 (at char 25), (line:2, col:13)")
+            "Error in HCVR: 10R => 2>!<;0, found ';'  (at char 25), (line:2, col:13)")
 
         with self.assertRaises(ParseException) as context:
             HCVR(rule)

--- a/pyvdrm/tests/test_hcvr.py
+++ b/pyvdrm/tests/test_hcvr.py
@@ -100,8 +100,6 @@ class TestRuleSemantics(unittest.TestCase):
         rule = HCVR("SCORE FROM (MIN (100G => -10, 101D => -20, 102D => 30))")
         self.assertEqual(-20, rule(VariantCalls("100G 101D 102d")))
 
-
-
     def test_bool_and(self):
         rule = HCVR("1G AND (2T AND 7Y)")
         self.assertEqual(rule(VariantCalls("2T 7Y 1G")), True)
@@ -121,6 +119,15 @@ class TestRuleSemantics(unittest.TestCase):
 
     def test_bool_or(self):
         rule = HCVR("1G OR (2T OR 7Y)")
+        self.assertTrue(rule(VariantCalls("1d 2T 7d")))
+        self.assertFalse(rule(VariantCalls("1d 2d 7d")))
+        self.assertTrue(rule(VariantCalls("1G 2d 7d")))
+        with self.assertRaisesRegex(MissingPositionError,
+                                    r"Missing position 1"):
+            rule([])
+
+    def test_bool_or_no_brackets(self):
+        rule = HCVR("1G OR 2T OR 7Y")
         self.assertTrue(rule(VariantCalls("1d 2T 7d")))
         self.assertFalse(rule(VariantCalls("1d 2d 7d")))
         self.assertTrue(rule(VariantCalls("1G 2d 7d")))


### PR DESCRIPTION
HIVdb versions >= 9.2 have rules (for comments) in the following form:
`33i OR 34i OR 35i`
This broke the parsing, because pyvdrm assumes only binary OR clauses like this:
`33i OR (34i OR 35i)`
This PR fixes this issue as well as some unit tests that has been broken.